### PR TITLE
[app] flutter <-> webview 양방향 통신

### DIFF
--- a/lib/src/controller/notification_controller.dart
+++ b/lib/src/controller/notification_controller.dart
@@ -1,23 +1,26 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:get/get.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 import 'package:get/get_state_manager/get_state_manager.dart';
 
 class NotificationController extends GetxController {
   static NotificationController get to => Get.find();
   FirebaseMessaging _messaging = FirebaseMessaging();
   RxMap<String, dynamic> message = Map<String, dynamic>().obs;
+  WebViewController controller;
 
   @override
   void onInit() {
     _initNotification();
-    _getToken();
+    getToken();
     super.onInit();
   }
 
-  Future<void> _getToken() async {
+  Future<String> getToken() async {
     try {
       String token = await _messaging.getToken();
-      print(token);
+      return token;
+
     } catch (e) {}
   }
 

--- a/lib/src/page/cbnu_alrami.dart
+++ b/lib/src/page/cbnu_alrami.dart
@@ -1,14 +1,53 @@
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:cbnu_alrami_app/src/controller/notification_controller.dart';
+import 'package:get/get.dart';
+import 'dart:async';
+import 'dart:io';
 
-class CbnuAlramiWebview extends StatelessWidget {
-  const CbnuAlramiWebview({Key key}) : super(key: key);
+class CbnuAlramiWebview extends StatefulWidget {
+  CbnuAlramiWebview({Key key}) : super(key: key);
 
   @override
+  State<CbnuAlramiWebview> createState() => CbnuAlramiWebviewState();
+}
+class CbnuAlramiWebviewState extends State<CbnuAlramiWebview> {
+  WebViewController _webViewController;
+
+  @override
+  void initState() {
+    super.initState();
+    // Enable virtual display.
+    if (Platform.isAndroid) WebView.platform = SurfaceAndroidWebView();
+  }
+  @override
   Widget build(BuildContext context) {
-    return const WebView(
-      initialUrl: 'https://dev-mobile.cmi.kro.kr/home', // 'https://dev-mobile.cmi.kro.kr'
+    final Completer<WebViewController> _controller =
+    Completer<WebViewController>();
+
+    NotificationController nc = new NotificationController();
+
+    return WebView(
+      initialUrl: 'http:10.0.2.2:3000/home', // 'https://dev-mobile.cmi.kro.kr'
       javascriptMode: JavascriptMode.unrestricted,
+      onWebViewCreated: (WebViewController webviewController)  {
+        _controller.complete(webviewController);
+        _webViewController = webviewController;
+      },
+      javascriptChannels: <JavascriptChannel>{
+        _baseJavascript(context),
+      },
+      onPageFinished: (String url) async {
+        dynamic token = await nc.getToken();
+        _webViewController.evaluateJavascript('localStorage.setItem("token", "${token}");');
+      },
     );
+  }
+  JavascriptChannel _baseJavascript(BuildContext context) {
+    return JavascriptChannel(
+        name: 'baseApp',
+        onMessageReceived: (JavascriptMessage message) {
+            print(message.message);
+        });
   }
 }


### PR DESCRIPTION
## 👀 이슈
resolve #13 

## 📌 개요
- `flutter`와 `webview`의 양방향 통신 구현 
- `localstorage`를 flutter에서 fcm token을 넣어주는 로직을 구현하였습니다. 

## 👩‍💻 작업 사항
- `flutter`와 `webview`의 양방향 통신 구현 
- `localstorage`를 flutter에서 fcm token을 넣어주는 로직을 구현하였습니다. 

## ✅ 참고 사항
- `webview_flutter`가 2.0.14 버전이라서 `runJavascript`가 적용이 안됩니다 -> evaluateJavascript로 구현
- javascriptChannels을 양방향 통신을 위해서 추가해주었습니다. 
- onPageFinished를 이용해서 webview가 다 로드될 때 로컬스토리지에 fcm token이 추가되는 방식으로 구현하였습니다. 
- ios 테스트가 필요합니다. 
